### PR TITLE
Use 'walk' speed as a placeholder fix due to FVTT/DND updates

### DIFF
--- a/CozyPlayer/cozy-player/scripts/token-tooltip.js
+++ b/CozyPlayer/cozy-player/scripts/token-tooltip.js
@@ -107,7 +107,7 @@ class TokenTooltip
     
     // Speed
     if(game.settings.get("cozy-player", "tooltipShowSpeed"))
-      TokenTooltip._addConstValue(resources, "speed", "fas fa-shoe-prints", object.actor.data.data.attributes.speed.value);
+      TokenTooltip._addConstValue(resources, "speed", "fas fa-shoe-prints", object.actor.data.data.attributes.movement.walk);
     
     // Passive Pereception
     if(game.settings.get("cozy-player", "tooltipPassivePerception"))


### PR DESCRIPTION
Changed attributes.speed.value to attributes.movement.walk due to actor data structure change following one of the latest updates.

This is a workaround to avoid tooltips not showing up and might not work completely since it lacks a proper nullcheck.